### PR TITLE
[asterisk_plus_account] fix update_reference for Odoo 15+ field rename

### DIFF
--- a/asterisk_plus_account/models/call.py
+++ b/asterisk_plus_account/models/call.py
@@ -18,8 +18,8 @@ class AccountCall(models.Model):
                     [
                         ('partner_id', '=', self.partner.id),
                         ('state', '=', 'posted'),
-                        ('type', 'in', ['out_invoice', 'in_invoice']),
-                        ('invoice_payment_state', '!=', 'paid'),
+                        ('move_type', 'in', ['out_invoice', 'in_invoice']),
+                        ('payment_state', '!=', 'paid'),
                     ], limit=1)
                 if account_move:
                     self.sudo().ref = account_move


### PR DESCRIPTION
## Summary
- `asterisk_plus_account/models/call.py:update_reference` queried `account.move` with the legacy fields `type` and `invoice_payment_state`, which were renamed to `move_type` and `payment_state` in Odoo 13/15. Each call with a matched partner and a falsy result from the parent `update_reference()` raised `ValueError: Invalid field account.move.invoice_payment_state`, leaving calls unlinked from outstanding invoices and spamming ERROR/Traceback into the log.
- Replace the two field names so the search executes correctly and the call's `ref` is set to the partner's open invoice.

## Test plan
Verified on a fresh Odoo 15.0 environment (`odoo:15.0`) with `asterisk_plus_account` freshly installed:

- [x] `account.move._fields` confirms: `type` MISSING, `move_type` PRESENT, `invoice_payment_state` MISSING, `payment_state` PRESENT.
- [x] Before fix, running the original domain raised `ValueError: Invalid field account.move.invoice_payment_state in leaf ('invoice_payment_state', '!=', 'paid')` (`odoo/osv/expression.py:656`).
- [x] After replacing with `move_type` / `payment_state`, the same search returns a valid (possibly empty) recordset without error.
- [ ] Smoke-test in 16.0, 17.0, 18.0, 19.0 branches once back-ported.