### PR TITLE
[asterisk_plus_account] fix update_reference for Odoo 15+ field rename

### DIFF
--- a/asterisk_plus_account/models/call.py
+++ b/asterisk_plus_account/models/call.py
@@ -18,8 +18,8 @@ class AccountCall(models.Model):
                     [
                         ('partner_id', '=', self.partner.id),
                         ('state', '=', 'posted'),
-                        ('type', 'in', ['out_invoice', 'in_invoice']),
-                        ('invoice_payment_state', '!=', 'paid'),
+                        ('move_type', 'in', ['out_invoice', 'in_invoice']),
+                        ('payment_state', '!=', 'paid'),
                     ], limit=1)
                 if account_move:
                     self.sudo().ref = account_move


### PR DESCRIPTION
## Summary
- Backport of PR #21 (18.0) / #22 (15.0) / #23 (16.0) to the 19.0 branch.
- `asterisk_plus_account/models/call.py:update_reference` queries `account.move` with the legacy fields `type` and `invoice_payment_state`, which were renamed to `move_type` and `payment_state` in Odoo 13+. On Odoo 19 every call with a matched partner and a falsy result from the parent `update_reference()` raises `ValueError: Invalid field account.move.type`, leaving calls unlinked from outstanding invoices and emitting ERROR/Traceback in the log.

## Test plan
Verified on a freshly provisioned Odoo 19.0 environment with `asterisk_plus_account` installed (override loaded from `/mnt/extra-addons/asterisk_plus_account/models/call.py`):

- [x] `account.move._fields`: `type` MISSING, `move_type` PRESENT, `invoice_payment_state` MISSING, `payment_state` PRESENT.
- [x] Before the fix the original domain raised `ValueError: Invalid field account.move.type in condition ('type', 'in', ['out_invoice', 'in_invoice'])`.
- [x] After replacing with `move_type` / `payment_state`, the same search returns a valid (possibly empty) recordset without error.