### PR TITLE
[asterisk_plus] fix Odoo 16 view syntax in license and settings

### DIFF
--- a/asterisk_plus/views/license.xml
+++ b/asterisk_plus/views/license.xml
@@ -39,15 +39,15 @@
                             <label for="subscribe_to_updates" class="me-2 w-75 w-sm-50 w-md-50 w-lg-25"/>
                             <field name="subscribe_to_updates" class="w-25 w-sm-50 w-md-50 w-lg-75"/>
                         </div>
-                        <div class="d-flex flex-row" invisible="not subscribe_to_security_alerts and not subscribe_to_onboarding and not subscribe_to_updates">
+                        <div class="d-flex flex-row" attrs="{'invisible': [('subscribe_to_security_alerts', '=', False), ('subscribe_to_onboarding', '=', False), ('subscribe_to_updates', '=', False)]}">
                             <label for="subscribe_email" string="Email for notifications" class="me-2 w-75 w-sm-50 w-md-50 w-lg-25"/>
-                            <field name="subscribe_email" class="w-25 w-sm-50 w-md-50 w-lg-75" required="subscribe_to_security_alerts or subscribe_to_onboarding or subscribe_to_updates"/>
+                            <field name="subscribe_email" class="w-25 w-sm-50 w-md-50 w-lg-75" attrs="{'required': ['|', '|', ('subscribe_to_security_alerts', '=', True), ('subscribe_to_onboarding', '=', True), ('subscribe_to_updates', '=', True)]}"/>
                         </div>
                         <group col="2">
                             <div colspan="2">
                                 <button name="update_license_status" string="UPDATE LICENSE / PRICING" type="object" class="btn-success me-2"/>
                                 <field name="all_modules_purchased" invisible="1"/>
-                                <button name="buy_all_licenses" string="BUY ALL MODULES" type="object" class="btn-warning" invisible="all_modules_purchased"/>
+                                <button name="buy_all_licenses" string="BUY ALL MODULES" type="object" class="btn-warning" attrs="{'invisible': [('all_modules_purchased', '=', True)]}"/>
                             </div>
                             <field name="oduist_modules" nolabel="1" colspan="2">
                                 <tree create="false" delete="false" decoration-danger="oduist_license_status == 'Trial Expired'">
@@ -57,7 +57,7 @@
                                     <field name="oduist_license_status" string="License Status" readonly="1"/>
                                     <field name="oduist_module_show_price" string="Info" readonly="1"/>
                                     <field name="oduist_module_purchased" invisible="1"/>
-                                    <button name="buy_oduist_license" string="Buy Module" type="object" class="btn-warning btn-sm" invisible="oduist_module_purchased"/>
+                                    <button name="buy_oduist_license" string="Buy Module" type="object" class="btn-warning btn-sm" attrs="{'invisible': [('oduist_module_purchased', '=', True)]}"/>
                                 </tree>
                             </field>
                         </group>

--- a/asterisk_plus/views/settings.xml
+++ b/asterisk_plus/views/settings.xml
@@ -95,11 +95,7 @@
                     </group>
                 </page>
                 <page name="transcription" string="Transcription"
-<<<<<<< HEAD
                       attrs="{'invisible': ['|',('record_calls', '=', False),('is_registered', '=', False)]}">
-=======
-                      invisible="record_calls == False">
->>>>>>> 330df6c ([OPL] Implement Oduist Proprietary License system for PBX modules)
                   <group>
                     <group>
                       <field name="transcribe_calls"/>

--- a/asterisk_plus/views/settings.xml
+++ b/asterisk_plus/views/settings.xml
@@ -21,12 +21,7 @@
         <form create="false" delete="false">
             <sheet>
               <notebook>
-<<<<<<< HEAD
-                <page name="general" string="General"
-                      attrs="{'invisible': [('is_registered', '=', False)]}">
-=======
                 <page name="general" string="General">
->>>>>>> 330df6c ([OPL] Implement Oduist Proprietary License system for PBX modules)
                   <group>
                     <group>
                       <field name="module_version"/>
@@ -46,12 +41,7 @@
                     </group>
                   </group>
                 </page>
-<<<<<<< HEAD
-                <page name="calls" string="Calls"
-                      attrs="{'invisible': [('is_registered', '=', False)]}">
-=======
                 <page name="calls" string="Calls">
->>>>>>> 330df6c ([OPL] Implement Oduist Proprietary License system for PBX modules)
                   <group>
                       <group string="Call Options" name="options" >
                         <field name="auto_create_partners" readonly="1" help="Enterprise Feature"/>
@@ -95,7 +85,7 @@
                     </group>
                 </page>
                 <page name="transcription" string="Transcription"
-                      attrs="{'invisible': ['|',('record_calls', '=', False),('is_registered', '=', False)]}">
+                      attrs="{'invisible': [('record_calls', '=', False)]}">
                   <group>
                     <group>
                       <field name="transcribe_calls"/>


### PR DESCRIPTION
## Summary
Three issues blocked installing `asterisk_plus` (and therefore `asterisk_plus_account`) on Odoo 16:

1. **`views/license.xml`** used the new `invisible="..."` / `required="..."` attribute syntax introduced in Odoo 17. On Odoo 16 the names inside the expression are not defined in the evaluation context, causing `NameError: name 'subscribe_to_security_alerts' is not defined` while parsing the license form view and aborting the module install. Converted to the Odoo 16-compatible `attrs="{...}"` domain syntax.

2. **`views/settings.xml`** had three blocks of unresolved Git merge-conflict markers (`<<<<<<< HEAD / ======= / >>>>>>>`) committed around the General, Calls, and Transcription page tags. The XML wouldn't even parse without resolving them.

3. The HEAD side of those conflicts referenced a field `is_registered` in the `attrs="..."` domains. That field does not exist anywhere in the `asterisk_plus` module (verified with grep across all version branches), so resolving in favour of HEAD would still fail with `Field 'is_registered' used in attrs ... must be present in view but is missing`. Resolved by dropping the phantom condition: the General and Calls pages are now always visible, and the Transcription page is conditional on the real `record_calls` field.

## Test plan
Verified on a freshly provisioned Odoo 16.0 environment:

- [x] Before fix: installing `asterisk_plus_account` (which depends on `asterisk_plus`) aborts with `ParseError: while parsing /mnt/extra-addons/asterisk_plus/views/license.xml:16 ... NameError: name 'subscribe_to_security_alerts' is not defined`.
- [x] With license.xml patched but settings.xml conflict markers still present: parse fails at `settings.xml:24` (unresolved markers — invalid XML).
- [x] With settings.xml HEAD-side `is_registered` attrs: parse passes but view validation rejects with `Field 'is_registered' used in attrs ... must be present in view but is missing`.
- [x] After full fix (this branch): `asterisk_plus_account` installs cleanly. 40 modules loaded, 0 ERRORs in the install log (only an unrelated license-check WARNING from the License module).